### PR TITLE
Idea how to fix wrong padding for 64 Byte long inputs

### DIFF
--- a/protostar.toml
+++ b/protostar.toml
@@ -1,10 +1,10 @@
 ["protostar.config"]
-protostar_version = "0.1.0"
+protostar_version = "0.3.0"
 
 ["protostar.project"]
 libs_path = "lib"
 
 ["protostar.contracts"]
 main = [
-    "./src/main.cairo",
+    "src/main.cairo",
 ]

--- a/src/sha256.cairo
+++ b/src/sha256.cairo
@@ -64,7 +64,6 @@ func _sha256_chunk{range_check_ptr, sha256_start: felt*, state: felt*, output: f
 
         _sha256_input_chunk_size_felts = int(ids.SHA256_INPUT_CHUNK_SIZE_FELTS)
         assert 0 <= _sha256_input_chunk_size_felts < 100
-
         w = compute_message_schedule(memory.get_range(
             ids.sha256_start, _sha256_input_chunk_size_felts))
         new_state = sha2_compress_function(memory.get_range(ids.state, int(ids.SHA256_STATE_SIZE_FELTS)), w)
@@ -86,7 +85,13 @@ func sha256_inner{range_check_ptr, sha256_ptr: felt*}(
 
     let (zero_bytes) = is_le(n_bytes, 0)
     let (zero_total_bytes) = is_le(total_bytes, 0)
-    let zero_chunk = zero_bytes - zero_total_bytes
+
+    # If the previous message block was full we are still missing "1" at the end of the message
+    let( _, r_div_by_64) = unsigned_div_rem(total_bytes, 64)
+    let (missing_bit_one) = is_le(r_div_by_64, 0)
+    
+    # This works for 0 total bytes too, because zero_chunk will be -1 and, therefore, not 0.
+    let zero_chunk = zero_bytes - zero_total_bytes - missing_bit_one
 
     let (is_last_block) = is_le(n_bytes, 55)
     if is_last_block != 0:
@@ -149,7 +154,7 @@ func _sha256_input{range_check_ptr, sha256_ptr: felt*}(
         memset(dst=sha256_ptr, value=0, n=n_words)
         let sha256_ptr = sha256_ptr + n_words
         return ()
-    end
+    end 
 
     if n_bytes == 0:
         # This is the last input word, so we should add a byte '0x80' at the end and fill the rest with
@@ -160,6 +165,7 @@ func _sha256_input{range_check_ptr, sha256_ptr: felt*}(
         return ()
     end
 
+   
     assert_nn_le(n_bytes, 3)
     let (padding) = pow(256, 3 - n_bytes)
     local range_check_ptr = range_check_ptr

--- a/tests/test_sha256.cairo
+++ b/tests/test_sha256.cairo
@@ -1,4 +1,3 @@
-
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
@@ -135,7 +134,6 @@ func test_sha256_0bits{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}():
     let h = hash[7]
     assert h = 0x7852b855
 
-
     return ()
 end
 
@@ -209,6 +207,102 @@ func test_sha256_448bits{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}():
     assert g = 0xf6ecedd4
     let h = hash[7]
     assert h = 0x19db06c1
+
+    return ()
+end
+
+@view
+func test_sha256_504bits{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}():
+    alloc_locals
+    # Input String: "0000111122223333444455556666777788889999aaaabbbbccccddddeeeefff"
+    let (input) = alloc()
+    assert input[0] = '0000'
+    assert input[1] = '1111'
+    assert input[2] = '2222'
+    assert input[3] = '3333'
+    assert input[4] = '4444'
+    assert input[5] = '5555'
+    assert input[6] = '6666'
+    assert input[7] = '7777'
+    assert input[8] = '8888'
+    assert input[9] = '9999'
+    assert input[10] = 'aaaa'
+    assert input[11] = 'bbbb'
+    assert input[12] = 'cccc'
+    assert input[13] = 'dddd'
+    assert input[14] = 'eeee'
+    assert input[15] = 'fff\x00'
+
+    let (local sha256_ptr : felt*) = alloc()
+    let sha256_ptr_start = sha256_ptr
+    let (hash) = sha256{sha256_ptr=sha256_ptr}(input, 63)
+    finalize_sha256(sha256_ptr_start=sha256_ptr_start, sha256_ptr_end=sha256_ptr)
+
+    # Resulting hash: 214072bf9da123ca5a8925edb05a6f071fc48fa66494d08513b9ba1b82df20cd
+    let a = hash[0]
+    assert a = 0x214072bf
+    let b = hash[1]
+    assert b = 0x9da123ca
+    let c = hash[2]
+    assert c = 0x5a8925ed
+    let d = hash[3]
+    assert d = 0xb05a6f07
+    let e = hash[4]
+    assert e = 0x1fc48fa6
+    let f = hash[5]
+    assert f = 0x6494d085
+    let g = hash[6]
+    assert g = 0x13b9ba1b
+    let h = hash[7]
+    assert h = 0x82df20cd
+
+    return ()
+end
+
+@view
+func test_sha256_512bits{bitwise_ptr : BitwiseBuiltin*, range_check_ptr}():
+    alloc_locals
+    # Input String: "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+    let (input) = alloc()
+    assert input[0] = '0000'
+    assert input[1] = '1111'
+    assert input[2] = '2222'
+    assert input[3] = '3333'
+    assert input[4] = '4444'
+    assert input[5] = '5555'
+    assert input[6] = '6666'
+    assert input[7] = '7777'
+    assert input[8] = '8888'
+    assert input[9] = '9999'
+    assert input[10] = 'aaaa'
+    assert input[11] = 'bbbb'
+    assert input[12] = 'cccc'
+    assert input[13] = 'dddd'
+    assert input[14] = 'eeee'
+    assert input[15] = 'ffff'
+
+    let (local sha256_ptr : felt*) = alloc()
+    let sha256_ptr_start = sha256_ptr
+    let (hash) = sha256{sha256_ptr=sha256_ptr}(input, 64)
+    finalize_sha256(sha256_ptr_start=sha256_ptr_start, sha256_ptr_end=sha256_ptr)
+
+    # Resulting hash: c7a7d8c0472c7f6234380e9dd3a55eb24d3e5dba9d106b74a260dc787f2f6df8
+    let a = hash[0]
+    assert a = 0xc7a7d8c0
+    let b = hash[1]
+    assert b = 0x472c7f62
+    let c = hash[2]
+    assert c = 0x34380e9d
+    let d = hash[3]
+    assert d = 0xd3a55eb2
+    let e = hash[4]
+    assert e = 0x4d3e5dba
+    let f = hash[5]
+    assert f = 0x9d106b74
+    let g = hash[6]
+    assert g = 0xa260dc78
+    let h = hash[7]
+    assert h = 0x7f2f6df8
 
     return ()
 end


### PR DESCRIPTION
The second message block was missing the "1" bit after the
input message. 
Fix is not clean at all and I just wanted to showcase the issue and a possible way to solve it. 
In particular ```test_sha256_512bits``` fails before the fix.